### PR TITLE
Feature/#106 alternate till next review

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,8 @@ jobs:
       - run:
           name: Rspec
           command: bundle exec rspec
+      - store_artifacts:
+        path: tmp/capybara/
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
           name: Rspec
           command: bundle exec rspec
       - store_artifacts:
-        path: tmp/capybara/
+          path: tmp/screenshots/
 
 workflows:
   version: 2.1

--- a/app/assets/stylesheets/BEM/home/home-top.scss
+++ b/app/assets/stylesheets/BEM/home/home-top.scss
@@ -16,7 +16,7 @@
     padding-right: 8px;
   }
   &__count {
-    padding-left: 3px;
+    padding: 0 7px;
   }
   &__start {
     @extend %__start;

--- a/app/models/learned_content.rb
+++ b/app/models/learned_content.rb
@@ -109,6 +109,8 @@ class LearnedContent < ApplicationRecord
   private
 
   def set_first_cycle
+    return if review_date.present?
+
     first_cycle = user.cycles.find_by(times: 0).cycle
     update!(review_date: Time.zone.today + first_cycle)
   end

--- a/app/models/learned_content.rb
+++ b/app/models/learned_content.rb
@@ -15,10 +15,11 @@ class LearnedContent < ApplicationRecord
 
   validates :content, presence: true, length: { maximum: 3000 }
 
-  scope :to_review_today, -> { where('till_next_review <= 0') }
-  scope :to_review_this_day, ->(date) { where('till_next_review = ? AND till_next_review >= 1', (date - Time.zone.today).to_i) }
-  scope :till_next_asc, -> { order(till_next_review: 'ASC') }
-  scope :latest, -> { order(id: 'DESC') }
+  scope :to_review_today, -> { where('review_date <= ?', Time.zone.today) }
+  scope :to_review_this_day,
+        ->(date) { where('review_date = ? AND review_date >= ?', date, Time.zone.today) }
+  scope :review_date_asc, -> { order(review_date: 'ASC') }
+  scope :latest, -> { order(created_at: 'DESC') }
   scope :all_or_weekly, ->(weekly) do
     if weekly
       where('created_at >= ?', Time.current.beginning_of_week)
@@ -28,8 +29,12 @@ class LearnedContent < ApplicationRecord
   end
 
   ransacker :favorites_count do
-    query = '(SELECT COUNT(favorites.learned_content_id) FROM favorites where favorites.learned_content_id = learned_contents.id GROUP BY favorites.learned_content_id)'
+    query = '(SELECT COUNT(favorites.learned_content_id) FROM favorites WHERE favorites.learned_content_id = learned_contents.id GROUP BY favorites.learned_content_id)'
     Arel.sql(query)
+  end
+
+  def till_next_review
+    @till_next_review ||= (review_date - Time.zone.today).to_i
   end
 
   def create_related_images(related_image_array)
@@ -72,9 +77,9 @@ class LearnedContent < ApplicationRecord
   def set_next_cycle
     times = review_histories.not_again.count
     if (next_cycle = user.cycles.find_by(times: times)&.cycle)
-      update(till_next_review: next_cycle)
+      update(review_date: Time.zone.today + next_cycle)
     else
-      update(till_next_review: 10000, completed: true)
+      update(review_date: Time.zone.today + 10000, completed: true)
     end
   end
 
@@ -105,8 +110,6 @@ class LearnedContent < ApplicationRecord
 
   def set_first_cycle
     first_cycle = user.cycles.find_by(times: 0).cycle
-    return if first_cycle == 1
-
-    update!(till_next_review: first_cycle)
+    update!(review_date: Time.zone.today + first_cycle)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,8 +142,8 @@ class User < ApplicationRecord
     )
   end
 
-  def set_calendar_to_review(till_next_review)
-    calendars.find_or_create_by!(calendar_date: Time.zone.today + till_next_review)
+  def set_calendar_to_review(review_date)
+    calendars.find_or_create_by!(calendar_date: review_date)
   end
 
   def rollback_to_default_cycle

--- a/app/views/homes/top.html.slim
+++ b/app/views/homes/top.html.slim
@@ -2,21 +2,21 @@
   .home-top
     span.home-top__span
       i.fas.fa-book-open.home-top__icon
-      | 本日の復習: 
+      | 本日の復習:
       span.home-top__count #{reviewed_count_today}
     span.home-top__span
       | /
     span.home-top__span
       span.home-top__count #{contents_to_review_today.count + reviewed_count_today}
     - if contents_to_review_today.count > 0
-      = link_to '復習スタート', question_learn_path(contents_to_review_today.till_next_asc.first, today: 1), class: 'home-top__start--top'
+      = link_to '復習スタート', question_learn_path(contents_to_review_today.review_date_asc.first, today: 1), class: 'home-top__start--top'
   .home-top
     span.home-top__span
       i.fa.fa-edit.fa-lg.home-top__icon
-      | 本日の学習: 
+      | 本日の学習:
       span.home-top__count= learned_contents_today.count
     = link_to '単語を学習', new_learn_path, class: 'home-top__start--bottom'
-  
+
   .home-calendar
     #calendar
 
@@ -40,4 +40,4 @@
 #hidden-link.hidden
 
 / question_show用
-#calendar-modal 
+#calendar-modal

--- a/app/views/homes/top.html.slim
+++ b/app/views/homes/top.html.slim
@@ -4,9 +4,7 @@
       i.fas.fa-book-open.home-top__icon
       | 本日の復習:
       span.home-top__count #{reviewed_count_today}
-    span.home-top__span
       | /
-    span.home-top__span
       span.home-top__count #{contents_to_review_today.count + reviewed_count_today}
     - if contents_to_review_today.count > 0
       = link_to '復習スタート', question_learn_path(contents_to_review_today.review_date_asc.first, today: 1), class: 'home-top__start--top'

--- a/app/views/learned_contents/_question-table.html.slim
+++ b/app/views/learned_contents/_question-table.html.slim
@@ -3,7 +3,7 @@ table.question-table
     tr
       th 問題
       th 復習回数
-      th= sort_link @q, :till_next_review, '復習まで', {}, { remote: true }
+      th= sort_link @q, :review_date, '復習まで', {}, { remote: true }
       th カテゴリー
       th= sort_link @q, :favorites_count, 'いいね数', { default_order: :desc }, { remote: true }
       th= sort_link @q, :created_at, '作成日', {}, { remote: true }

--- a/app/views/learned_contents/answer.html.slim
+++ b/app/views/learned_contents/answer.html.slim
@@ -14,7 +14,7 @@
 
       .answer-box
         .answer-box__ans--my
-          h3.answer-box__heading My answer 
+          h3.answer-box__heading My answer
           p.answer-box__text= question.my_answer
         .answer-box__between
           span class="answer-box__similarity--#{similarity_to_color(question.similarity)}" #{question.similarity}%
@@ -29,7 +29,7 @@
     p.question-container__finished 本日の復習は終了しました。
   .question-container__links
     - if @today == '1' && contents_to_review_today.any?
-      = link_to 'Next', question_learn_path(contents_to_review_today.till_next_asc.first, today: 1), class: 'question-container__btn--next'
+      = link_to 'Next', question_learn_path(contents_to_review_today.review_date_asc.first, today: 1), class: 'question-container__btn--next'
     - if session[:question_back]
       = link_to 'Next', communities_questions_path(back: 1), class: 'question-container__finish-btn'
     - else

--- a/app/views/learned_contents/show.html.slim
+++ b/app/views/learned_contents/show.html.slim
@@ -21,11 +21,11 @@
           h3 Q#{index + 1}
           = simple_format question.question
           .learn-grid-container__answer-show
-            strong A: 
+            strong A:
             span= question.answer
       .learn-grid-container__subtle
         .learn-grid-container__category--show
-          strong Category: 
+          strong Category:
           span= @learned_content.word_category.category
         .learn-grid-container__public--show
           - if @learned_content.is_public
@@ -51,7 +51,7 @@
         = f.label :again, 'Again: '
         = f.check_box :again, class: 'onclick-select'
       - if contents_to_review_today.any?
-        = link_to 'Next', question_learn_path(contents_to_review_today.till_next_asc.first, today: 1), class: 'learn-show-bottom__next'
+        = link_to 'Next', question_learn_path(contents_to_review_today.review_date_asc.first, today: 1), class: 'learn-show-bottom__next'
       = link_to 'Finish', root_path, class: 'learn-show-bottom__finish'
   - elsif session[:question_back]
     .learn-show-bottom__today

--- a/app/views/learned_contents/show.html.slim
+++ b/app/views/learned_contents/show.html.slim
@@ -21,11 +21,11 @@
           h3 Q#{index + 1}
           = simple_format question.question
           .learn-grid-container__answer-show
-            strong A:
+            <strong>A: </strong>
             span= question.answer
       .learn-grid-container__subtle
         .learn-grid-container__category--show
-          strong Category:
+          <strong>Category: </strong>
           span= @learned_content.word_category.category
         .learn-grid-container__public--show
           - if @learned_content.is_public

--- a/db/migrate/20200516132027_add_column_to_learned_content.rb
+++ b/db/migrate/20200516132027_add_column_to_learned_content.rb
@@ -1,0 +1,5 @@
+class AddColumnToLearnedContent < ActiveRecord::Migration[6.0]
+  def change
+    add_column :learned_contents, :review_date, :date
+  end
+end

--- a/db/migrate/20200516132830_remove_column_from_learned_contents.rb
+++ b/db/migrate/20200516132830_remove_column_from_learned_contents.rb
@@ -1,0 +1,15 @@
+class RemoveColumnFromLearnedContents < ActiveRecord::Migration[6.0]
+  class LearnedContent < ActiveRecord::Base
+  end
+
+  def up
+    LearnedContent.find_each do |learned_content|
+      learned_content.update!(review_date: Time.zone.today + learned_content.till_next_review)
+    end
+    remove_column :learned_contents, :till_next_review, :integer
+  end
+
+  def down
+    add_column :learned_contents, :till_next_review, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_16_052030) do
+ActiveRecord::Schema.define(version: 2020_05_16_132830) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -117,7 +117,6 @@ ActiveRecord::Schema.define(version: 2020_05_16_052030) do
     t.bigint "word_category_id", null: false
     t.bigint "word_definition_id", null: false
     t.boolean "is_public", default: true
-    t.integer "till_next_review", default: 1
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "imported", default: false
@@ -125,6 +124,7 @@ ActiveRecord::Schema.define(version: 2020_05_16_052030) do
     t.bigint "calendar_id", null: false
     t.integer "imported_from"
     t.boolean "is_test", default: false
+    t.date "review_date"
     t.index ["calendar_id"], name: "index_learned_contents_on_calendar_id"
     t.index ["created_at", "imported_from", "is_public"], name: "index_learned_contents_imported_latest"
     t.index ["user_id", "imported_from"], name: "index_learned_contents_on_user_id_and_imported_from"

--- a/spec/factories/learned_content.rb
+++ b/spec/factories/learned_content.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     word_definition
     word_category
     calendar
+    review_date { Time.zone.today + 1 }
   end
 end

--- a/spec/system/contents_index_spec.rb
+++ b/spec/system/contents_index_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
   it 'contents can be sorted and reserved' do
     # 問題一覧
     click_link 'テストユーザー'
+    sleep(0.2)
     find('a', text: '問題一覧').click
     # 作成日順
     expect(page).to have_content '2021/01/15'
@@ -222,6 +223,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
 
     # user_900でログイン（他人の問題をダウンロードした後の挙動を知るため）
     click_link 'テストユーザー'
+    sleep(0.2)
     find('a', text: 'ログアウト').click
     actual_sign_in_as user_900
     find('.header-right__toggler--community').click
@@ -257,6 +259,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     click_link 'Question'
     fill_in 'A:', with: 'answer'
     click_button 'Submit'
+    sleep(0.2)
     find('a', text: 'Next').click
     sleep(0.3)
     expect(page).to have_select('スキルで探す:', selected: 'TOEIC800点相当')
@@ -270,6 +273,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     click_button 'Submit'
     sleep(0.3)
     click_link 'Download'
+    sleep(0.2)
     find('a', text: '"star"').click
     sleep(0.3)
     click_link 'Next'

--- a/spec/system/contents_index_spec.rb
+++ b/spec/system/contents_index_spec.rb
@@ -164,31 +164,30 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
 
     # ユーザースキル 900 1件
     select 'TOEIC900点相当', from: 'スキルで探す:'
-    wait_for_ajax
+    sleep(0.4)
     expect(page).to have_selector('tbody tr', count: 1)
     expect(page).to have_content 'General 900 Q'
 
     # ユーザースキル 800
     select 'TOEIC800点相当', from: 'スキルで探す:'
-    wait_for_ajax
+    sleep(0.4)
     expect(page).to_not have_content 'General 900 Q'
     paginate_and_wait(2)
     expect(page).to_not have_content 'General 900 Q'
 
     # カテゴリー General with 800 なし
     select 'General', from: 'カテゴリーで探す:'
-    wait_for_ajax
+    sleep(0.4)
     expect(page).to_not have_selector('tbody tr')
 
     # カテゴリー General with 900 1件
     select 'TOEIC900点相当', from: 'スキルで探す:'
-    wait_for_ajax
     expect(page).to have_selector('tbody tr', count: 1)
     expect(page).to have_content 'General 900 Q'
 
     # カテゴリー Technology with 900 なし
     select 'Technology', from: 'カテゴリーで探す:'
-    wait_for_ajax
+    sleep(0.4)
     expect(page).to_not have_selector('tbody tr')
 
     # カテゴリー Technology with 800 1件
@@ -219,7 +218,6 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     # セッションを設定
     expect(page).to_not have_content 'Technology Q'
     select 'TOEIC800点相当', from: 'スキルで探す:'
-    wait_for_ajax
     sleep(0.5)
     click_link 'いいね数' # 降順
     sleep(0.5)
@@ -243,7 +241,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     click_link 'Question'
     fill_in 'A:', with: 'answer'
     click_button 'Submit'
-    click_link 'Next'
+    find('a', text: 'Next').click
     expect(page).to have_select('スキルで探す:', selected: 'TOEIC800点相当')
     expect(page).to have_content 'Technology Q'
 
@@ -255,6 +253,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     click_button 'Submit'
     click_link 'Download'
     find('a', text: '"star"').click
+    wait_for_ajax
     click_link 'Next'
     expect(page).to have_select('スキルで探す:', selected: 'TOEIC800点相当')
     expect(page).to have_content 'Technology Q'
@@ -273,13 +272,13 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
 
     # スキル900 main: lead 1件
     select 'TOEIC900点相当', from: 'スキルで探す:'
-    wait_for_ajax
+    sleep(0.4)
     expect(page).to have_selector('tbody tr', count: 1)
     expect(page).to have_selector('td', text: 'lead')
 
     # スキル800 main: star, test 15件
     select 'TOEIC800点相当', from: 'スキルで探す:'
-    wait_for_ajax
+    sleep(0.4)
     expect(page).to have_selector('td:nth-child(1)', text: 'star')
     expect(page).to have_selector('td:nth-child(2)', text: 'test')
     expect(page).to_not have_selector('td', text: 'lead')
@@ -288,7 +287,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
 
     # スキル800, Technology main: star, test 1件
     select 'Technology', from: 'カテゴリーで探す:'
-    wait_for_ajax
+    sleep(0.4)
     expect(page).to have_selector('td:nth-child(1)', text: 'star')
     expect(page).to have_selector('td:nth-child(2)', text: 'test')
     expect(page).to have_selector('tbody tr', count: 1)

--- a/spec/system/contents_index_spec.rb
+++ b/spec/system/contents_index_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     # 作成日順
     expect(page).to have_content '2021/01/15'
     click_link '作成日'
+    sleep(0.3)
     expect(page).to have_selector('.sort_link.asc', text: '作成日')
     expect(page).to have_selector('td', text: '2021/01/01')
     expect(page).to_not have_content '2021/01/15'
@@ -74,9 +75,11 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     # いいね順
     paginate_and_wait 1
     click_link 'いいね数'
+    sleep(0.3)
     expect(page).to have_selector('.sort_link.desc', text: 'いいね数')
     expect(page).to have_selector('tr:first-child td:nth-child(5)', text: '1')
     click_link 'いいね数'
+    sleep(0.3)
     expect(page).to have_selector('.sort_link.asc', text: 'いいね数')
     expect(page).to_not have_selector('td:nth-child(5)', text: '1')
     paginate_and_wait 2
@@ -93,7 +96,9 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     sleep(0.4)
     expect(page).to have_selector('td:nth-child(3)', text: '15日')
     paginate_and_wait 1
+    sleep(0.3)
     click_link '復習まで' # 降順
+    sleep(0.3)
     expect(page).to have_selector('.sort_link.desc', text: '復習まで')
     expect(page).to have_selector('tr:first-child td:nth-child(3)', text: '15日')
     expect(page).to_not have_selector('td:nth-child(3)', text: /^1日/)
@@ -106,7 +111,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     expect(page).to have_selector('tbody tr', count: 1)
     expect(page).to have_content 'Technology Q'
     select 'Science', from: 'カテゴリーで探す:'
-    wait_for_ajax
+    sleep(0.4)
     expect(page).to_not have_content 'Technology Q'
     paginate_and_wait(2)
     expect(page).to_not have_content 'Technology Q'
@@ -118,14 +123,17 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     expect(page).to_not have_selector('tbody tr')
     fill_in '単語で探す:', with: 'test'
     click_button 'button'
+    sleep(0.3)
     expect(page).to have_selector('tbody tr')
 
     # 単語で検索 カテゴリーtechnology 関連語testが検索される
     select 'Technology', from: 'カテゴリーで探す:'
+    sleep(0.3)
     expect(page).to have_selector('tbody tr', count: 1)
     expect(page).to have_content 'Technology Q'
     fill_in '単語で探す:', with: 'star'
     click_button 'button'
+    sleep(0.3)
     expect(page).to have_selector('tbody tr', count: 1)
     expect(page).to have_content 'Technology Q'
 
@@ -138,6 +146,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     wait_for_css_disappear('tbody tr')
     expect(page).to_not have_selector('tbody tr')
     select 'All', from: 'カテゴリーで探す:'
+    sleep(0.3)
     expect(page).to have_selector('tbody tr')
 
     # みんなの問題
@@ -147,6 +156,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     # 作成日順
     expect(page).to have_selector('tr:first-child td:nth-child(5)', text: '2021/01/15')
     click_link '作成日'
+    sleep(0.3)
     expect(page).to have_selector('.sort_link.asc', text: '作成日')
     expect(page).to_not have_content '2021/01/15'
     paginate_and_wait(2)
@@ -155,9 +165,11 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     # いいね順
     paginate_and_wait(1)
     click_link 'いいね数'
+    sleep(0.3)
     expect(page).to have_selector('.sort_link.desc', text: 'いいね数')
     expect(page).to have_selector('tr:first-child td:nth-child(4)', text: '1')
     click_link 'いいね数'
+    sleep(0.3)
     expect(page).to have_selector('.sort_link.asc', text: 'いいね数')
     expect(page).to_not have_selector('td:nth-child(4)', text: '1')
     paginate_and_wait(2)
@@ -193,15 +205,16 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
 
     # カテゴリー Technology with 800 1件
     select 'TOEIC800点相当', from: 'スキルで探す:'
-    wait_for_ajax
+    sleep(0.3)
     expect(page).to have_selector('tbody tr', count: 1)
     expect(page).to have_content 'Technology Q'
 
     # カテゴリー Science with 800 15件 ソートもできる
     select 'Science', from: 'カテゴリーで探す:'
-    wait_for_ajax
+    sleep(0.3)
     expect(page).to have_selector('tr:first-child td', text: '2021/01/15')
     click_on '作成日'
+    sleep(0.3)
     expect(page).to have_selector('.sort_link.asc', text: '作成日')
     expect(page).to_not have_content '2021/01/15'
     paginate_and_wait(2)
@@ -255,6 +268,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     click_link 'Question'
     fill_in 'A:', with: 'answer'
     click_button 'Submit'
+    sleep(0.3)
     click_link 'Download'
     find('a', text: '"star"').click
     sleep(0.3)
@@ -273,6 +287,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     # 単語を探す デフォルトは作成日降順
     find('.header-right__toggler--community').click
     find('.community-menu__list', text: '単語を探す').click
+    sleep(0.5)
     expect(page).to have_content 'lead'
     expect(page).to have_content 'star'
 

--- a/spec/system/contents_index_spec.rb
+++ b/spec/system/contents_index_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
                        calendar: calendar_800,
                        word_category: word_category_science,
                        word_definition: word_definition_test,
-                       till_next_review: 15 - n,
+                       review_date: Time.zone.today + 15 - n,
                        created_at: Time.zone.local(2021, 1, n + 1))
       create(:question,
              learned_content: content,

--- a/spec/system/contents_index_spec.rb
+++ b/spec/system/contents_index_spec.rb
@@ -287,28 +287,28 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     # 単語を探す デフォルトは作成日降順
     find('.header-right__toggler--community').click
     find('.community-menu__list', text: '単語を探す').click
-    sleep(0.5)
-    expect(page).to have_content 'lead'
-    expect(page).to have_content 'star'
+    sleep(0.2)
+    expect(page).to_not have_content 'lead'
+    expect(page).to_not have_content 'star'
 
     # スキル900 main: lead 1件
     select 'TOEIC900点相当', from: 'スキルで探す:'
-    sleep(0.4)
+    sleep(0.3)
     expect(page).to have_selector('tbody tr', count: 1)
     expect(page).to have_selector('td', text: 'lead')
 
     # スキル800 main: star, test 15件
     select 'TOEIC800点相当', from: 'スキルで探す:'
-    sleep(0.4)
-    expect(page).to have_selector('td:nth-child(1)', text: 'star')
-    expect(page).to have_selector('td:nth-child(2)', text: 'test')
+    sleep(0.3)
     expect(page).to_not have_selector('td', text: 'lead')
     paginate_and_wait 2
+    expect(page).to have_selector('td:nth-child(1)', text: 'star')
+    expect(page).to have_selector('td:nth-child(2)', text: 'test')
     expect(page).to_not have_selector('td', text: 'lead')
 
     # スキル800, Technology main: star, test 1件
     select 'Technology', from: 'カテゴリーで探す:'
-    sleep(0.4)
+    sleep(0.3)
     expect(page).to have_selector('td:nth-child(1)', text: 'star')
     expect(page).to have_selector('td:nth-child(2)', text: 'test')
     expect(page).to have_selector('tbody tr', count: 1)

--- a/spec/system/contents_index_spec.rb
+++ b/spec/system/contents_index_spec.rb
@@ -212,6 +212,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     actual_sign_in_as user_900
     find('.header-right__toggler--community').click
     find('.community-menu__list', text: 'みんなの問題').click
+    sleep(0.3)
     expect(page).to have_select('スキルで探す:', selected: 'All')
     expect(page).to have_select('カテゴリーで探す:', selected: 'All')
 
@@ -229,38 +230,42 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
 
     # 問題ページから戻る
     click_link 'Technology Q'
-    wait_for_ajax
+    sleep(0.3)
     click_link 'Question'
     click_link 'Back'
+    sleep(0.3)
     expect(page).to have_select('スキルで探す:', selected: 'TOEIC800点相当')
     expect(page).to have_content 'Technology Q'
 
     # 回答ページから戻る
     click_link 'Technology Q'
-    wait_for_ajax
+    sleep(0.3)
     click_link 'Question'
     fill_in 'A:', with: 'answer'
     click_button 'Submit'
     find('a', text: 'Next').click
+    sleep(0.3)
     expect(page).to have_select('スキルで探す:', selected: 'TOEIC800点相当')
     expect(page).to have_content 'Technology Q'
 
     # ダウンロードしたshowページから戻る
     click_link 'Technology Q'
-    wait_for_ajax
+    sleep(0.3)
     click_link 'Question'
     fill_in 'A:', with: 'answer'
     click_button 'Submit'
     click_link 'Download'
     find('a', text: '"star"').click
-    wait_for_ajax
+    sleep(0.3)
     click_link 'Next'
+    sleep(0.3)
     expect(page).to have_select('スキルで探す:', selected: 'TOEIC800点相当')
     expect(page).to have_content 'Technology Q'
 
     # ナビバーから戻るとセッションは残っていない
     find('.header-right__toggler--community').click
     find('.community-menu__list', text: 'みんなの問題').click
+    sleep(0.3)
     expect(page).to have_select('スキルで探す:', selected: 'All')
     expect(page).to have_select('カテゴリーで探す:', selected: 'All')
 

--- a/spec/system/contents_index_spec.rb
+++ b/spec/system/contents_index_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe 'Index of contents', type: :system, js: true, vcr: { cassette_nam
     expect(page).to have_selector('tr:first-child td:nth-child(3)', text: '1日')
     expect(page).to_not have_selector('td:nth-child(3)', text: '15日')
     paginate_and_wait 2
+    sleep(0.4)
     expect(page).to have_selector('td:nth-child(3)', text: '15日')
     paginate_and_wait 1
     click_link '復習まで' # 降順

--- a/spec/system/import_contents_spec.rb
+++ b/spec/system/import_contents_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'import contents', type: :system, js: true, vcr: { cassette_name:
            user: owner,
            calendar: calendar,
            word_definition: word_definition_lead,
-           till_next_review: 0)
+           review_date: Time.zone.today)
   end
 
   before do

--- a/spec/system/import_contents_spec.rb
+++ b/spec/system/import_contents_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe 'import contents', type: :system, js: true, vcr: { cassette_name:
   end
 
   it 'community questions can be imported' do
-    expect(page).to have_content '本日の復習: 0/0'
-    expect(page).to have_content '本日の学習: 0'
+    expect(page).to have_content '本日の復習:0/0'
+    expect(page).to have_content '本日の学習:0'
     expect(page).to_not have_content 'Q about lead'
     find('.header-right__toggler--community').click
     find('.community-menu__list', text: 'みんなの問題').click

--- a/spec/system/levels_spec.rb
+++ b/spec/system/levels_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Level', type: :system, js: true, vcr: { cassette_name: 'apis' },
                                word_definition: word_definition,
                                word_category: word_category,
                                calendar: calendar,
-                               till_next_review: 0)
+                               review_date: Time.zone.today)
       case n
       when 0
         question = 'Q for 90%'

--- a/spec/system/levels_spec.rb
+++ b/spec/system/levels_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe 'Level', type: :system, js: true, vcr: { cassette_name: 'apis' },
     visit root_path
 
     # 90%以上 4exp
-    sleep(0.3)
     set_exp(user: user, exp: 3)
     click_link '復習スタート'
     fill_in 'A:', with: 'a' * 9 + 'b'

--- a/spec/system/levels_spec.rb
+++ b/spec/system/levels_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe 'Level', type: :system, js: true, vcr: { cassette_name: 'apis' },
     visit root_path
 
     # 90%以上 4exp
+    sleep(0.3)
     set_exp(user: user, exp: 3)
     click_link '復習スタート'
     fill_in 'A:', with: 'a' * 9 + 'b'

--- a/spec/system/new_learns_spec.rb
+++ b/spec/system/new_learns_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'New Learn', type: :system, retry: 3 do
       click_on 'more'
       find_field('Question 2').fill_in with: 'Another Question'
       click_button 'Save'
-      sleep(0.3)
+      sleep(0.5)
       expect(page).to have_selector('.error-message__list', text: '答えを入力してください')
     }.to change(user.learned_contents, :count).by(0)
 

--- a/spec/system/questions_spec.rb
+++ b/spec/system/questions_spec.rb
@@ -11,21 +11,21 @@ RSpec.describe 'Questions', type: :system, js: true, vcr: { cassette_name: 'apis
            user: user,
            calendar: calendar_yesterday,
            word_definition: word_definition_lead,
-           till_next_review: 0)
+           review_date: Time.zone.today)
   end
   let(:leraned_content_today2) do
     create(:learned_content,
            user: user,
            calendar: calendar_yesterday,
            word_definition: word_definition_lead,
-           till_next_review: 0)
+           review_date: Time.zone.today)
   end
   let(:leraned_content_tommorow) do
     create(:learned_content,
            user: user,
            calendar: calendar_today,
            word_definition: word_definition_lead,
-           till_next_review: 1)
+           review_date: Time.zone.today + 1)
   end
 
   before do
@@ -196,7 +196,9 @@ RSpec.describe 'Questions', type: :system, js: true, vcr: { cassette_name: 'apis
     expect(page).to_not have_content 'Again'
 
     # 次の日に設定
-    LearnedContent.update_all('till_next_review = till_next_review - 1')
+    LearnedContent.all.each do |learned_content|
+      learned_content.update!(review_date: learned_content.review_date - 1)
+    end
     visit root_path
     aggregate_failures do
       expect(page).to have_content '本日の復習: 2/4'

--- a/spec/system/questions_spec.rb
+++ b/spec/system/questions_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe 'Questions', type: :system, js: true, vcr: { cassette_name: 'apis
 
   it 'user has questions to answer today' do
     aggregate_failures do
-      expect(page).to have_content '本日の復習: 0/2'
-      expect(page).to have_content '本日の学習: 1'
+      expect(page).to have_content '本日の復習:0/2'
+      expect(page).to have_content '本日の学習:1'
       expect(page).to have_selector 'h3:nth-child(1)', text: '本日の復習'
       expect(page).to have_selector 'li:nth-child(2)', text: 'Learn1 Q1'
       expect(page).to have_selector 'li:nth-child(3)', text: 'Learn2 Q1'
@@ -165,7 +165,7 @@ RSpec.describe 'Questions', type: :system, js: true, vcr: { cassette_name: 'apis
 
     # 明日の復習予定は2つ（元々のものと、againに指定したもの）
     visit root_path
-    expect(page).to have_content '本日の復習: 2/2'
+    expect(page).to have_content '本日の復習:2/2'
     expect(page).to have_content '復習完了!'
     click_on '復習予定: 2' # カレンダー
     within '#calendar-show' do
@@ -201,7 +201,7 @@ RSpec.describe 'Questions', type: :system, js: true, vcr: { cassette_name: 'apis
     end
     visit root_path
     aggregate_failures do
-      expect(page).to have_content '本日の復習: 2/4'
+      expect(page).to have_content '本日の復習:2/4'
       expect(page).to have_selector 'h3:nth-child(1)', text: '本日の復習'
       expect(page).to have_selector 'li:nth-child(2)', text: 'Learn1 Q1'
       expect(page).to have_selector 'li:nth-child(3)', text: 'Tommorow question'


### PR DESCRIPTION
fixes #106

### Summary
Refactored so that review cycles of learned contents can be updated without crontab.
### Other Information
Column review_date was added and till_next_review column was removed.